### PR TITLE
Initial pass at adding deprecation documentation for O3DE

### DIFF
--- a/governance/ApiDeprecation.md
+++ b/governance/ApiDeprecation.md
@@ -19,8 +19,9 @@ Examples of a API deprecation:
 
 ## Process
 
-> ### Golden Rule
-> Do not make any breaking changes to an API when first deprecating it (this includes adding the AZ_DEPRECATED macro). The code must work exactly as before.
+### Golden Rule
+
+> Do not make any breaking changes to an API when first deprecating it (this includes adding the `AZ_DEPRECATED` macro). The code must work exactly as before.
 
 ### Steps (Guide)
 

--- a/governance/ApiDeprecation.md
+++ b/governance/ApiDeprecation.md
@@ -30,21 +30,21 @@ Examples of a API deprecation:
     1. Add the Deprecation label.
     1. In the Description, add a preliminary Release Note (what do you want to say to the customer about this change).
     1. Fill in the Release Note Required field to identify which release this deprecation will be going out in.
-1. Add a `O3DE_DEPRECATED(<GHI Number>)` comment right above the API call.
+1. Add a `O3DE_DEPRECATION_NOTICE(<GHI Number>)` comment right above the API call.
     1. e.g.
 ```c++
-    // O3DE_DEPRECATED(GHI-1234)
+    // O3DE_DEPRECATION_NOTICE(GHI-1234)
     AZ::Entity* CreateEditorEntity(const char* name) = 0;
 ```
 > Aside: To make searching easier, only add API comments to the function/type declarations, not definitions.
 1. Create second GHI to add `AZ_DEPRECATED` to the API.
     1. Add the Deprecation label.
-    1. Set this issue to be Blocked by the first issue.
+    1. Link the issues together.
     1. _Note: If it isn't possible to use the `AZ_DEPRECATED` macro, create a ticket and make a note it will apply in Release + 2 (so a maximum of only two GHIs need be created in this case)_
 1. _LATER_ (after the first issue is Closed, i.e. a Release has actually happened) create another GitHub issue to remove the code entirely (please see Tracking Information below for details about this).
     1. Add the Deprecation label.
-    1. Set this issue to be Blocked by the second issue.
-    1. Add the `AZ_DEPRECATED` macro to the code (leaving the `O3DE_DEPRECATED` comment in place to help with searching) and submit (referencing both Git Hub numbers in the CL description).
+    1. Link this issue to the second issue.
+    1. Add the `AZ_DEPRECATED` macro to the code (leaving the `O3DE_DEPRECATION_NOTICE` comment in place to help with searching) and submit (referencing both Git Hub numbers in the CL description).
 1. _MUCH LATER_ (after the second issue is Closed, i.e. the second Release has actually happened)
     1. Remove the code and create a PR
     1. Set final issue to be Closed (will be closed by release team)
@@ -52,19 +52,19 @@ Examples of a API deprecation:
 
 ### Tracking (Informational)
 
-1. When a Release is imminent, sig-documentaion will (rip)grep the repo for all occurrences of `O3DE_DEPRECATED`
+1. When a Release is imminent, sig-documentaion will (rip)grep the repo for all occurrences of `O3DE_DEPRECATION_NOTICE`
 1. They will confirm what stage the issue is in (following the issue chain) and add the info in the Description to the Release Notes.
 1. sig-documentation will then update the issue to Closed
     1. When this happens, the engineer who began the deprecation will get a notification from GitHub of the change, and at this time they know it is okay to move to the next stage (add `AZ_DEPRECATED` (part 2), delete code (part 3)).
 
-### Find all O3DE_DEPRECATED tags
+### Find all O3DE_DEPRECATION_NOTICE tags
 
 ```bash
 # prerequisites
 # ripgrep - https://github.com/BurntSushi/ripgrep/releases
 # cmder - https://cmder.net/
  
-rg O3DE_DEPRECATED\(GHI\-([0-9]+)\) --replace https://github.com/o3de/o3de/issues/$1 --iglob *.{h,hpp,c,cpp,inl,hxx} -o -I | sort | uniq > deprecations.txt
+rg O3DE_DEPRECATION_NOTICE\(GHI\-([0-9]+)\) --replace https://github.com/o3de/o3de/issues/$1 --iglob *.{h,hpp,c,cpp,inl,hxx} -o -I | sort | uniq > deprecations.txt
  
 # this will generate a list of Git Hub issue numbers to be updated when a Release is imminent.
 ```
@@ -73,7 +73,7 @@ rg O3DE_DEPRECATED\(GHI\-([0-9]+)\) --replace https://github.com/o3de/o3de/issue
 
 Use of the `AZ_DEPRECATED` macro is now not allowed when first deprecating an API.
 
-It is now required to first use the comment identifier `O3DE_DEPRECATED`, and a second pass (corresponding to the second Git Hub issue), to add `AZ_DEPRECATED`.
+It is now required to first use the comment identifier `O3DE_DEPRECATION_NOTICE`, and a second pass (corresponding to the second Git Hub issue), to add `AZ_DEPRECATED`.
 
 `AZ_DEPRECATED` cannot be used effectively as a first step in deprecation because the warning generated will cause a compiler error for many customers building with warnings as errors.
 

--- a/governance/ApiDeprecation.md
+++ b/governance/ApiDeprecation.md
@@ -1,0 +1,115 @@
+# API Deprecation
+
+> Unsure about what type of deprecation you're facing? Please see this page for more information - [Deprecation Meta](DeprecationMeta.md)
+
+> Wondering if this applies to you? This process only applies to public APIs - if you're sure consumers of your API will not be impacted, making an immediate change is okay.
+
+## Overview
+
+Examples of a API deprecation:
+
+- Renaming a function
+- Renaming a class/EBus
+- Changing a function signature
+- Removing a function
+- Removing a class/EBus
+- Changing the address type of an EBus
+- Changing the preconditions of a function
+- e.g. Function no longer handles nullptrs or parameter values must now fall within a specified range (e.g. between `0.0` and `1.0`).
+
+## Process
+
+> ### Golden Rule
+> Do not make any breaking changes to an API when first deprecating it (this includes adding the AZ_DEPRECATED macro). The code must work exactly as before.
+
+### Steps (Guide)
+
+1. Identify the code to be deprecated (something resembling one of the API deprecation examples outlined in the Overview).
+1. Create a new GitHub issue with the name "Deprecate <Function/Type Name>"
+    1. Add the Deprecation label.
+    1. In the Description, add a preliminary Release Note (what do you want to say to the customer about this change).
+    1. Fill in the Release Note Required field to identify which release this deprecation will be going out in.
+1. Add a `O3DE_DEPRECATED(<GHI Number>)` comment right above the API call.
+    1. e.g.
+```c++
+    // O3DE_DEPRECATED(GHI-1234)
+    AZ::Entity* CreateEditorEntity(const char* name) = 0;
+```
+> Aside: To make searching easier, only add API comments to the function/type declarations, not definitions.
+1. Create second GHI to add `AZ_DEPRECATED` to the API.
+    1. Add the Deprecation label.
+    1. Set this issue to be Blocked by the first issue.
+    1. _Note: If it isn't possible to use the `AZ_DEPRECATED` macro, create a ticket and make a note it will apply in Release + 2 (so a maximum of only two GHIs need be created in this case)_
+1. _LATER_ (after the first issue is Closed, i.e. a Release has actually happened) create another GitHub issue to remove the code entirely (please see Tracking Information below for details about this).
+    1. Add the Deprecation label.
+    1. Set this issue to be Blocked by the second issue.
+    1. Add the `AZ_DEPRECATED` macro to the code (leaving the `O3DE_DEPRECATED` comment in place to help with searching) and submit (referencing both Git Hub numbers in the CL description).
+1. _MUCH LATER_ (after the second issue is Closed, i.e. the second Release has actually happened)
+    1. Remove the code and create a PR
+    1. Set final issue to be Closed (will be closed by release team)
+    1. You're done!
+
+### Tracking (Informational)
+
+1. When a Release is imminent, sig-documentaion will (rip)grep the repo for all occurrences of `O3DE_DEPRECATED`
+1. They will confirm what stage the issue is in (following the issue chain) and add the info in the Description to the Release Notes.
+1. sig-documentation will then update the issue to Closed
+    1. When this happens, the engineer who began the deprecation will get a notification from GitHub of the change, and at this time they know it is okay to move to the next stage (add `AZ_DEPRECATED` (part 2), delete code (part 3)).
+
+### Find all O3DE_DEPRECATED tags
+
+```bash
+# prerequisites
+# ripgrep - https://github.com/BurntSushi/ripgrep/releases
+# cmder - https://cmder.net/
+ 
+rg O3DE_DEPRECATED\(GHI\-([0-9]+)\) --replace https://github.com/o3de/o3de/issues/$1 --iglob *.{h,hpp,c,cpp,inl,hxx} -o -I | sort | uniq > deprecations.txt
+ 
+# this will generate a list of Git Hub issue numbers to be updated when a Release is imminent.
+```
+
+### Advice
+
+Use of the `AZ_DEPRECATED` macro is now not allowed when first deprecating an API.
+
+It is now required to first use the comment identifier `O3DE_DEPRECATED`, and a second pass (corresponding to the second Git Hub issue), to add `AZ_DEPRECATED`.
+
+`AZ_DEPRECATED` cannot be used effectively as a first step in deprecation because the warning generated will cause a compiler error for many customers building with warnings as errors.
+
+The macro is useful for providing more information about how to update a particular call if it is being replaced.
+
+### FAQ
+
+#### Introducing alternative calls
+
+When first deprecating a function, it is advisable to not fix all call sites using the old version of the API. It may be wise to keep both variations active during the first stage of deprecation to ensure both calls do what you expect (e.g. Have the old call delegate to the new API and keep using that version for the first release, before the `AZ_DEPRECATED` macro is added). Depending on the situation it may be advisable to add a unit test to verify the behaviour of both calls. This helps avoid accidental, silent failures earlier.
+
+#### Deprecating EBus Functions
+
+When marking an EBus interface function `AZ_DEPRECATED`, any class that derives from that interface will generate `C4996 deprecation warnings`. This is caused by the `EBus::Handler` (the type that is actually inherited from) calling those functions internally in the EBus template code.
+
+To work around this, you need to wrap any class implementing that interface in
+
+```c++
+AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations")
+AZ_POP_DISABLE_WARNING
+```
+
+```c++
+class YourRequests
+{
+    // ...
+    AZ_DEPRECATED(virtual void OldFunction() = 0, "OldFunction is being replaced by NewFunction.");
+};
+ 
+using YourRequestBus = AZ::EBus<YourRequests>;
+ 
+AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations")
+class YourClass
+    : public YourRequestBus::Handler
+{
+    // ...
+    void OldFunction() override;
+};
+AZ_POP_DISABLE_WARNING
+```

--- a/governance/ApiDeprecation.md
+++ b/governance/ApiDeprecation.md
@@ -1,8 +1,12 @@
 # API Deprecation
 
-> Unsure about what type of deprecation you're facing? Please see this page for more information - [Deprecation Meta](DeprecationMeta.md)
+## Notice
 
-> Wondering if this applies to you? This process only applies to public APIs - if you're sure consumers of your API will not be impacted, making an immediate change is okay.
+> Wondering if this applies to you? This process only applies to __public__ APIs. If you're sure consumers of your API will not be impacted, making an immediate change is okay.
+
+## Info
+
+> Unsure about what type of deprecation you're facing? Please see this page for more information - [Deprecation Meta](DeprecationMeta.md)
 
 ## Overview
 
@@ -15,7 +19,7 @@ Examples of a API deprecation:
 - Removing a class/EBus
 - Changing the address type of an EBus
 - Changing the preconditions of a function
-- e.g. Function no longer handles nullptrs or parameter values must now fall within a specified range (e.g. between `0.0` and `1.0`).
+  - e.g. Function no longer handles `nullptr`s or parameter values must now fall within a specified range (e.g. between `0.0` and `1.0`).
 
 ## Process
 
@@ -26,36 +30,37 @@ Examples of a API deprecation:
 ### Steps (Guide)
 
 1. Identify the code to be deprecated (something resembling one of the API deprecation examples outlined in the Overview).
-1. Create a new GitHub issue with the name "Deprecate <Function/Type Name>"
-    1. Add the Deprecation label.
-    1. In the Description, add a preliminary Release Note (what do you want to say to the customer about this change).
-    1. Fill in the Release Note Required field to identify which release this deprecation will be going out in.
-1. Add a `O3DE_DEPRECATION_NOTICE(<GHI Number>)` comment right above the API call.
-    1. e.g.
-```c++
-    // O3DE_DEPRECATION_NOTICE(GHI-1234)
-    AZ::Entity* CreateEditorEntity(const char* name) = 0;
-```
-> Aside: To make searching easier, only add API comments to the function/type declarations, not definitions.
-1. Create second GHI to add `AZ_DEPRECATED` to the API.
-    1. Add the Deprecation label.
-    1. Link the issues together.
-    1. _Note: If it isn't possible to use the `AZ_DEPRECATED` macro, create a ticket and make a note it will apply in Release + 2 (so a maximum of only two GHIs need be created in this case)_
-1. _LATER_ (after the first issue is Closed, i.e. a Release has actually happened) create another GitHub issue to remove the code entirely (please see Tracking Information below for details about this).
-    1. Add the Deprecation label.
-    1. Link this issue to the second issue.
-    1. Add the `AZ_DEPRECATED` macro to the code (leaving the `O3DE_DEPRECATION_NOTICE` comment in place to help with searching) and submit (referencing both Git Hub numbers in the CL description).
-1. _MUCH LATER_ (after the second issue is Closed, i.e. the second Release has actually happened)
-    1. Remove the code and create a PR
-    1. Set final issue to be Closed (will be closed by release team)
+    1. _Note: It's fine to group several related changes into a single deprecation_.
+1. Create a new GitHub issue using the Deprecation issue template (this will come with all the required labels/milestones).
+    1. In the description, add a preliminary Release Note (what do you want to say to the customer about this change).
+1. Add an `O3DE_DEPRECATION_NOTICE(<GHI Number>)` comment right above the API call(s). For example:
+
+    ```c++
+        // O3DE_DEPRECATION_NOTICE(GHI-1234)
+        AZ::Entity  CreateEditorEntity(const char* name) = 0;
+    ```
+
+    > Aside: To make searching easier, only add API comments to the function/type declarations, not definitions.
+1. The Deprecation template comes with with three tasks:
+    1. Add deprecation notice
+    1. Add deprecation warning
+        1. _Note: This will vary depending on the language. C++ uses the `AZ_DEPRECATED` macro, Python can use [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). Please ask in the relevant sigs for more detail if required._
+    1. Remove deprecated code
+        1. _Note: If it isn't possible to perform task 2 (e.g. the language/environment does not support a deprecation warning), indicate it is blocked until another release has occurred._
+1. Create a PR with the deprecation notice outlined in __step 3__ (task 1) and add a reference to it on the deprecation GitHub issue.
+1. _LATER_ (after the release has actually happened). Create another PR to add the deprecation warning (reference this in the description next to task 2).
+    1. E.g. If using C++, add the `AZ_DEPRECATED` macro to the code (leaving the `O3DE_DEPRECATION_NOTICE` comment in place to help with searching) and merge.
+1. _MUCH LATER_ (after the next release has happened)
+    1. Remove the code and create a PR. Reference this in the description next to task 3.
+    1. Close the issue.
     1. You're done!
 
 ### Tracking (Informational)
 
-1. When a Release is imminent, sig-documentaion will (rip)grep the repo for all occurrences of `O3DE_DEPRECATION_NOTICE`
-1. They will confirm what stage the issue is in (following the issue chain) and add the info in the Description to the Release Notes.
-1. sig-documentation will then update the issue to Closed
-    1. When this happens, the engineer who began the deprecation will get a notification from GitHub of the change, and at this time they know it is okay to move to the next stage (add `AZ_DEPRECATED` (part 2), delete code (part 3)).
+1. When a Release is imminent, sig-documentaion will (rip)grep the repo for all occurrences of `O3DE_DEPRECATION_NOTICE`.
+    1. They may also use GitHub directly to search for all issues with the `kind/deprecation` label.
+1. They will confirm what stage the issue is in (by reviewing the task list) and add the information in the description to the Release Notes.
+1. At this stage, the engineer who began the deprecation will be notified, and at this time they know it is okay to move to the next stage (add `AZ_DEPRECATED` (task 2), delete code (task 3)).
 
 ### Find all O3DE_DEPRECATION_NOTICE tags
 
@@ -63,9 +68,9 @@ Examples of a API deprecation:
 # prerequisites
 # ripgrep - https://github.com/BurntSushi/ripgrep/releases
 # cmder - https://cmder.net/
- 
+
 rg O3DE_DEPRECATION_NOTICE\(GHI\-([0-9]+)\) --replace https://github.com/o3de/o3de/issues/$1 --iglob *.{h,hpp,c,cpp,inl,hxx} -o -I | sort | uniq > deprecations.txt
- 
+
 # this will generate a list of Git Hub issue numbers to be updated when a Release is imminent.
 ```
 
@@ -73,9 +78,9 @@ rg O3DE_DEPRECATION_NOTICE\(GHI\-([0-9]+)\) --replace https://github.com/o3de/o3
 
 Use of the `AZ_DEPRECATED` macro is now not allowed when first deprecating an API.
 
-It is now required to first use the comment identifier `O3DE_DEPRECATION_NOTICE`, and a second pass (corresponding to the second Git Hub issue), to add `AZ_DEPRECATED`.
+It is now required to first use the comment identifier `O3DE_DEPRECATION_NOTICE`, and a second pass (corresponding to the second task on the GitHub issue), to add `AZ_DEPRECATED`.
 
-`AZ_DEPRECATED` cannot be used effectively as a first step in deprecation because the warning generated will cause a compiler error for many customers building with warnings as errors.
+`AZ_DEPRECATED` cannot be used effectively as a first step in deprecation because the warning generated will cause a compile error for many customers building with warnings as errors.
 
 The macro is useful for providing more information about how to update a particular call if it is being replaced.
 
@@ -102,9 +107,9 @@ class YourRequests
     // ...
     AZ_DEPRECATED(virtual void OldFunction() = 0, "OldFunction is being replaced by NewFunction.");
 };
- 
+
 using YourRequestBus = AZ::EBus<YourRequests>;
- 
+
 AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations")
 class YourClass
     : public YourRequestBus::Handler

--- a/governance/DeprecationMeta.md
+++ b/governance/DeprecationMeta.md
@@ -12,15 +12,15 @@ When modifying existing code that external customers rely on we should strive wh
 
 If code is to be changed or removed, we should let customers know ahead of time with a reasonable notice period (approximately 2 releases (2-3 months))
 
-## Product Deprecation vs API Deprecation
+## Feature Deprecation vs API Deprecation
 
-We define *Product* deprecation as deprecating (and then replacing or removing) a system or feature (usually user facing).
+We define *Feature* deprecation as deprecating (and then replacing or removing) a system or feature (usually user facing).
 
 We define *API* deprecation as a change to a public API which would cause customer code to no longer compile or behave unexpectedly. Put another way, *API* deprecation is a change to an API which requires customer action should the deprecated code be removed.
 
-If your deprecation need fits the description of Product - please consult these documents for the process to follow:
+If your deprecation need fits the description of Feature - please consult these documents for the process to follow:
 
-[Product Deprecation](ProductDeprecation.md)
+[Feature Deprecation](FeatureDeprecation.md)
 
 If your deprecation aligns more closes with an API deprecation, please consult this document:
 

--- a/governance/DeprecationMeta.md
+++ b/governance/DeprecationMeta.md
@@ -1,0 +1,27 @@
+# Deprecation Meta
+
+# Overview
+
+This document contains high-level information about O3DE's approach to deprecation.
+
+It details language and terms used when categorizing types of deprecation.
+
+## Philosophy
+
+When modifying existing code that external customers rely on we should strive wherever possible to not break them when making changes.
+
+If code is to be changed or removed, we should let customers know ahead of time with a reasonable notice period (approximately 2 releases (2-3 months))
+
+## Product Deprecation vs API Deprecation
+
+We define *Product* deprecation as deprecating (and then replacing or removing) a system or feature (usually user facing).
+
+We define *API* deprecation as a change to a public API which would cause customer code to no longer compile or behave unexpectedly. Put another way, *API* deprecation is a change to an API which requires customer action should the deprecated code be removed.
+
+If your deprecation need fits the description of Product - please consult these documents for the process to follow:
+
+[Product Deprecation](ProductDeprecation.md)
+
+If your deprecation aligns more closes with an API deprecation, please consult this document:
+
+[API Deprecation](ApiDeprecation.md)

--- a/governance/FeatureDeprecation.md
+++ b/governance/FeatureDeprecation.md
@@ -1,4 +1,4 @@
-# Product Deprecation
+# Feature Deprecation
 
 # Overview
 

--- a/governance/ProductDeprecation.md
+++ b/governance/ProductDeprecation.md
@@ -1,0 +1,26 @@
+# Product Deprecation
+
+# Overview
+
+This document aims to describe how to handle system/feature level deprecations that will impact customers.
+
+## Steps
+
+When looking to deprecate a feature from O3DE, please follow the run book below:
+
+1. Start the sig notification process ideally three releases prior to final deprecation:
+    1. Contact sig-documentation to ensure they are able to make any required changes.
+    1. Contact sig-release to let them know of the planned deprecation.
+        1. GitHub issue should cover:
+            - What is being deprecated
+            - Why it's being deprecated. 
+            - Target deprecation date.
+            - How does this impact customers? 
+            - Detail what tech will be replacing the feature and whether the new tech will have feature parity. 
+            - Who can I contact if I have questions, concerns or general feedback.
+    1. If there are no concerns from sig-release and the relevant sig the feature applies to:
+        - Communicate to the sig that the feature is on the path to deprecation (Impactful Change notification on Discord).
+        - Update the status of the deprecation plan in the relevant sig meetings.
+    1. Make the replacement available (that is feature competitive with the original feature).
+        - See how many customers plan to stay with the old version.
+        - Deprecate (remove) the older feature, usually within 90 days.


### PR DESCRIPTION
This is a first-pass attempt taking the guidance we had during the Lumberyard days and mapping it to O3DE. I've done my best to update the wording to reference O3DE, Git Hub issues and the sigs. I've no doubt missed something though.

I'm happy to do a few updates but perhaps once this foundation is posted someone else from sig-release can take it over and tweak/change/update as they see fit.

If we think this is too far from something we want I can close this PR.

I've also created a PR for a deprecation issue template (suggested by @mcphedar) - https://github.com/o3de/o3de/pull/5395