### PR TITLE
Update Meeting-Agenda-Template.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/Meeting-Agenda-Template.md
+++ b/.github/ISSUE_TEMPLATE/Meeting-Agenda-Template.md
@@ -22,15 +22,3 @@ The [SIG-Release Meetings](https://github.com/o3de/sig-release/tree/main/meeting
 ## Meeting Agenda
 
 **Discuss agenda from proposed topics**
-
-## Outcomes from Discussion topics
-
-**Discuss outcomes from agenda**
-
-## Action Items
-
-**Create actionable items from proposed topics**
-
-## Open Discussion Items
-
-List any additional items below!


### PR DESCRIPTION
Removed sections from the meeting agenda template that we don't use. These sections are basically meeting notes, which we keep in a separate file.

Signed-off-by: Tony Balandiuk <85971417+tonybalandiuk@users.noreply.github.com>