### PR TITLE
Adding Python 3.10 update to release notes

### DIFF
--- a/releases/22.10.0/22100 feature list.md
+++ b/releases/22.10.0/22100 feature list.md
@@ -48,6 +48,7 @@ The general theme of this release is "TBD".
 ## sig-operations
 
 ## sig-platform
+* Update Python from version 3.7.12 to 3.10.5. This will increase the window for support and security updates for Python to 2026 ([PEP 619](https://peps.python.org/pep-0619/)) as well as brings in many language and performance improvements over Python 3.7. See the [Python Update RFC](https://github.com/o3de/sig-platform/issues/54) for further details.
 
 ## sig-security
 


### PR DESCRIPTION
Adding release note entry for Python 3.10

Python Update RFC: https://github.com/o3de/sig-platform/issues/54
Commit [607c548](https://github.com/o3de/o3de/commit/607c548791f2170b4d23a8cac191be1b834ca15b)

**Pull Requests for Feature:**
https://github.com/o3de/3p-package-source/pull/122
https://github.com/o3de/3p-package-source/pull/123
https://github.com/o3de/3p-package-source/pull/124
https://github.com/o3de/3p-package-source/pull/125
https://github.com/o3de/o3de/pull/11216

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>