### PR TITLE
Add roadmap issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-item.md
@@ -1,13 +1,13 @@
 ---
 name: 'Roadmap Item'
-about: Create Roadmap Item for this project
+about: Create roadmap item for this project
 title: Roadmap Item =description=
 labels: kind/roadmap
 assignees: ''
 
 ---
 
-# O3DE RFC Feature Template
+# O3DE Roadmap Item Template
 
 ### When using this template, you do not have to fill out every question below. The questions are there for guidance.
 

--- a/.github/ISSUE_TEMPLATE/roadmap-item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-item.md
@@ -19,7 +19,10 @@ This roadmap item template should be used for any feature that shows in the O3DE
 Single paragraph explanation of the roadmap item
 
 ### What is the relevance of this feature?
-What problems does it solves? Why is this important? What are the use cases? What will it do once completed?
+- What problems does it solves? 
+- Why is this important? 
+- What will it do once completed?
+- Are there any changes or impacts to other features? 
 
 ### Tasks
 What tasks are necessary to complete the roadmap item?

--- a/.github/ISSUE_TEMPLATE/roadmap-item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-item.md
@@ -1,0 +1,61 @@
+---
+name: 'Roadmap Item'
+about: Create Roadmap Item for this project
+title: Roadmap Item =description=
+labels: kind/roadmap
+assignees: ''
+
+---
+
+# O3DE RFC Feature Template
+
+### When using this template, you do not have to fill out every question below. The questions are there for guidance.
+
+This roadmap item template should be used for any feature that shows in the O3DE public roadmap. The issue communicates the initiative and vision of the SIG.
+
+# ----- DELETE EVERYTHING FROM THE TOP TO THE SUMMARY LINE BELOW WHEN USING TEMPLATE ----- #
+
+### Summary:
+Single paragraph explanation of the roadmap item
+
+### What is the relevance of this feature?
+What problems does it solves? Why is this important? What are the use cases? What will it do once completed?
+
+### Feature design description:
+- Explain the design of the feature with enough detail that someone familiar with the environment and framework can understand the concept and explain it to others. 
+- It should include at least one end-to-end example of how a developer will use it along with specific details, including outlying use cases. 
+
+- If there is any new terminology, it should be defined here.
+
+### Technical design description:
+- Explain the technical portion of the work in enough detail that members can implement the feature. 
+
+- Explain any API or process changes required to implement this feature
+
+- This section should relate to the feature design description by reference and explain in greater detail how it makes the feature design examples work.
+
+- This should also provide detailed information on compatibility with different hardware platforms.
+
+### What are the advantages of the feature?
+- Explain the advantages for someone to use this feature
+
+### What are the disadvantages of the feature?
+- Explain any disadvantages for someone to use this feature
+
+### How will this be implemented or integrated into the O3DE environment?
+- Explain how a developer will integrate this into the codebase of O3DE and provide any specific library or technical stack requirements.
+
+### Are there any alternatives to this feature?
+- Provide any other designs that have been considered. Explain what the impact might be of not doing this.
+- If there is any prior art or approaches with other frameworks in the same domain, explain how they may have solved this problem or implemented this feature.
+
+### How will users learn this feature?
+- Detail how it can be best presented and how it is used as an extension or a standalone tool used with O3DE.
+- Explain if and how it may change how individuals would use the platform and if any documentation must be changed or reorganized.
+- Explain how it would be taught to new and existing O3DE users.
+
+### Are there any open questions?
+- What are some of the open questions and potential scenarios that should be considered?
+
+### Tasks
+- What are tasks that are part of the roadmap item? Please paste the Github issues in this section.

--- a/.github/ISSUE_TEMPLATE/roadmap-item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-item.md
@@ -21,41 +21,8 @@ Single paragraph explanation of the roadmap item
 ### What is the relevance of this feature?
 What problems does it solves? Why is this important? What are the use cases? What will it do once completed?
 
-### Feature design description:
-- Explain the design of the feature with enough detail that someone familiar with the environment and framework can understand the concept and explain it to others. 
-- It should include at least one end-to-end example of how a developer will use it along with specific details, including outlying use cases. 
-
-- If there is any new terminology, it should be defined here.
-
-### Technical design description:
-- Explain the technical portion of the work in enough detail that members can implement the feature. 
-
-- Explain any API or process changes required to implement this feature
-
-- This section should relate to the feature design description by reference and explain in greater detail how it makes the feature design examples work.
-
-- This should also provide detailed information on compatibility with different hardware platforms.
-
-### What are the advantages of the feature?
-- Explain the advantages for someone to use this feature
-
-### What are the disadvantages of the feature?
-- Explain any disadvantages for someone to use this feature
-
-### How will this be implemented or integrated into the O3DE environment?
-- Explain how a developer will integrate this into the codebase of O3DE and provide any specific library or technical stack requirements.
-
-### Are there any alternatives to this feature?
-- Provide any other designs that have been considered. Explain what the impact might be of not doing this.
-- If there is any prior art or approaches with other frameworks in the same domain, explain how they may have solved this problem or implemented this feature.
-
-### How will users learn this feature?
-- Detail how it can be best presented and how it is used as an extension or a standalone tool used with O3DE.
-- Explain if and how it may change how individuals would use the platform and if any documentation must be changed or reorganized.
-- Explain how it would be taught to new and existing O3DE users.
-
-### Are there any open questions?
-- What are some of the open questions and potential scenarios that should be considered?
-
 ### Tasks
-- What are tasks that are part of the roadmap item? Please paste the Github issues in this section.
+What tasks are necessary to complete the roadmap item?
+
+### Related Links
+Link to additional informaton such as RFC related to the roadmap item.


### PR DESCRIPTION
This will be the roadmap item issue template. The information is very similar to the O3DE RFC Feature template. The differences are
1. I remove RFC-related occurrences.
2. I add the "Tasks" section.
3. I add the label "kind/roadmap".

I add you all as reviewers so you all can give input on the roadmap issue template as I proposed in https://github.com/o3de/sig-release/issues/79. I'll close the PR by January 6th PST if there are no major concerns and then I'll create PR for each of the SIG's repo.