### PR TITLE
Add needs-triage and checklist as a reference

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-item.md
@@ -2,7 +2,7 @@
 name: 'Roadmap Item'
 about: Create roadmap item for this project
 title: Roadmap Item =description=
-labels: kind/roadmap
+labels: kind/roadmap, needs-triage
 assignees: ''
 
 ---
@@ -26,6 +26,8 @@ Single paragraph explanation of the roadmap item
 
 ### Tasks
 What tasks are necessary to complete the roadmap item?
+- [ ] _GitHub issue 1 link_
+- [ ] _GitHub issue 2 link and so on._
 
 ### Related Links
 Link to additional informaton such as RFC related to the roadmap item.


### PR DESCRIPTION
# Changes
1. Add a needs-triage label if the roadmap item needs to be triaged. If it's already triaged, then you can remove it.
2. Add a checklist as a reference so the maintainer what use the suggested format to link respective tasks. 

# Description
The context of the roadmap item can be read here: https://github.com/o3de/sig-release/issues/79.

Signed-off-by: Vincent <vincentbiasa6767@gmail.com>