### PR TITLE
Add o3de-extras to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
         options:
           - o3de
           - o3de-atom-sampleviewer
+          - o3de-extras
           - o3de-multiplayersample
           - o3de-netsoaktest
       release_tag:


### PR DESCRIPTION
A small workflow configuration change to allow tagging the `o3de-extras` repository