### PR TITLE
Create Release Notes for 25.05.1

### DIFF
--- a/releases/25.05.1/25.05.1.md
+++ b/releases/25.05.1/25.05.1.md
@@ -25,6 +25,7 @@
 ## Sig-Simulation
 - Remove obsolete `requirements.txt` file from the ROS2 Gem.
 - Fix `ROS2FrameComponentInterface` that does not work correctly when called from AssetBuilder for URDF and SDF files.
+- Remove unused material slot descriptions from assets in `WarehouseAssets` and `ROS2SampleRobots` Gems
 
 ## Additional notes
 O3DE 25.05.1 was tested with **Microsoft Visual Studio 2022 17.4** (build tools: 19.44.35211) on Windows and **Clang 18** on Linux. If you are experiencing compilation errors when building the engine from source, please try to add these exact versions to your current development environment. Then, you can select the suggested compiler version when generating the engine solution for the first time (see *Step 3* of the official documentation for [Windows](https://docs.o3de.org/docs/welcome-guide/setup/setup-from-github/building-windows/#build-instructions) or [Linux](https://docs.o3de.org/docs/welcome-guide/setup/setup-from-github/building-linux/#build-instructions)):


### PR DESCRIPTION
Release notes of the first point release for `25.05`. It is based on the PRs that are already merged into the `point-release/25051` branches for [o3de](https://github.com/o3de/o3de) and [o3de-extras](https://github.com/o3de/o3de-extras) repositories. See the full project board at: https://github.com/orgs/o3de/projects/73