### PR TITLE
Update Release Notes for 25.05.1

### DIFF
--- a/releases/25.05.1/25.05.1.md
+++ b/releases/25.05.1/25.05.1.md
@@ -37,4 +37,4 @@
     ```sh
     cmake -B build/linux -S . -G "Ninja Multi-Config" -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18
     ```
-- An error message complaining about missing `xcb-input` library may happen when building the engine with an old Linux distribution. If you are using Ubuntu 22.04 LTS (or similar), please consider upgrading your default **CMake** installation to at least version **3.27**.
+- In the next release of O3DE the minimum requirement for **CMake** will be set to version **3.28.3**, in order to support the latest changes under development. If you are using Ubuntu 22.04 LTS (or similar), please consider upgrading your default **CMake** installation.


### PR DESCRIPTION
Add a note for upgrading CMake on old Linux distros, due to the error that was recently discovered in the Automated Review (AR) system.