### PR TITLE
Update Release Notes for 25.10.0

### DIFF
--- a/releases/25.10.0/25.10.0.md
+++ b/releases/25.10.0/25.10.0.md
@@ -367,4 +367,4 @@ The `WarehouseAutomation` Gem is planned to be removed in the next release as it
     ```sh
     cmake -B build/linux -S . -G "Ninja Multi-Config" -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18
     ```
-- O3DE 25.10 requires that Git must be installed on the system to build projects. You can try to install from https://git-scm.com/install/windows in case a CMake error occurs while building. The requirement will be removed in the next 25.10.1 version.
+- O3DE 25.10 requires that Git be installed in order to fetch and build projects. A Windows based installer can be located at [https://git-scm.com/install/windows](https://git-scm.com/install/windows) in the event that a CMake error occurs while building a project. The requirement will be removed in the next point release 25.10.1.

--- a/releases/25.10.0/25.10.0.md
+++ b/releases/25.10.0/25.10.0.md
@@ -367,3 +367,4 @@ The `WarehouseAutomation` Gem is planned to be removed in the next release as it
     ```sh
     cmake -B build/linux -S . -G "Ninja Multi-Config" -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18
     ```
+- O3DE 25.10 requires that Git must be installed on the system to build projects. You can try to install from https://git-scm.com/install/windows in case a CMake error occurs while building. The requirement will be removed in the next 25.10.1 version.


### PR DESCRIPTION
Add a warning message that Git is required in this release, due to the installation errors that have been reported by the community.