### PR TITLE
Sig-Release Meeting notes for Dec 16th 2025

### DIFF
--- a/meetings/notes/2025 - Dec 16th.md
+++ b/meetings/notes/2025 - Dec 16th.md
@@ -1,0 +1,31 @@
+## Meeting Details
+
+- **Date/Time:** Dec 16th, 2025 @ 5:30pm UTC / 9:30am PT
+- **Location:** [Discord SIG-Release Voice Room](https://discord.gg/Z2bzwCRJEz)
+- **Moderator**: @nickschuetz
+- **Note Taker**: @nickschuetz
+- **Agenda**: Open
+
+## SIG Updates
+
+Release updates:
+- 25.10.1 was released on 12/09/25 and is now available on https://o3de.org. Docs followed on 12/16/25.
+
+## Meeting Notes
+1. 25.10.1 point release docs issue has been resolved and the point release is now fully available.
+2. Discussed how migration to GitHub Actions will impact sig-release and future releases going forward. We may need to have some knowledge trasfer from sig-build for good measure.
+3. Discussed how we can better the documentation release process with @JT-SCB-GameDesign. The plan is to have a updated runbook before the next release in April.
+4. Continued planning for the 26.04.0 release in April with a look at current O3DE Roadmap items: https://github.com/orgs/o3de/projects/56
+5. Disscused closing the gaps on the "lottery test" to ensure smooth releases going forward in case of core contributor absences.
+   
+
+## Action Items
+1. @nickschuetz and @matteogrs to meet in Jan 2026 about sig release process change proposal to go over any adjustments needed.
+2. @JT-SCB-GameDesign and the rest of the #sig-docs-community to provide an updated docs release runbook. They will also be going over how GitHub Actions can help the docs release automation process.
+3. @nickschuetz and @matteogrs to go over O3DE Roadmap with @Ulrick28.
+
+## Special Notes
+
+We are going to make a temporary variation to upcoming meetings due to holidays:
+23 December was moved to 16 December (today) (at the same hour - 9:30 PT / 18:30 CET), 6 January is cancelled, The standard bi-weekly scheduling will be resumed on the 20th of January.
+


### PR DESCRIPTION
Meeting notes for Dec 16th, 2025, including changes to time zone, added SIG updates, and clarified action items.