### PR TITLE
Fix archive prefix in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           git archive -o ${{ steps.vars.outputs.archive_file }}.zip HEAD
           git archive -o ${{ steps.vars.outputs.archive_file }}.tar.gz HEAD
-          git archive --prefix=o3de -o ${{ steps.vars.outputs.archive_file_alt }}.tar.gz HEAD
+          git archive --prefix=o3de/ -o ${{ steps.vars.outputs.archive_file_alt }}.tar.gz HEAD
       
       - name: Split archive files if over limit
         run: | # MAXSIZE = 2GB


### PR DESCRIPTION
## What does this do
- Fixes the root path for the LFS archive 

## How was this tested
- Tested in my private fork and confirmed untar to a `o3de/` folder

